### PR TITLE
Fix Installation markdown header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Supported Ruby Interpreters
 * JRuby
 * Rubinius
 
-##Installation
+## Installation
 
     gem install webmock
 


### PR DESCRIPTION
Noticed there was a space missing which meant a header didn't get styled properly. This fixes that.